### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.11"
+  - "0.10"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 zamano-api
 ==========
 
+[![NPM](https://nodei.co/npm/zamano-api.png)](https://nodei.co/npm/zamano-api/)
+[![NPM](https://nodei.co/npm-dl/zamano-api.png)](https://nodei.co/npm/zamano-api/)
+
 Node.js API for Zamano, a mobile message aggregation service.  Allows servers to send and recieve mobile text and binary messages.
 
 Version: 0.1.5


### PR DESCRIPTION
Adds basic Travis CI and npm information so that users can easily see where the project is at.  Addresses issue #1 .
